### PR TITLE
Don't modify argument when serialising special ops

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,6 +18,7 @@ test_requires 'Test::More' => '0.94', # want note(), explain(), subtest() and do
 
 test_requires 'XML::Simple';
 test_requires 'Test::Mock::LWP' => '0.05';
+test_requires 'Storable' => '0.5';
 
 tests_recursive;
 

--- a/lib/WebService/Solr/Query.pm
+++ b/lib/WebService/Solr/Query.pm
@@ -102,15 +102,16 @@ sub _dispatch_value {
     {
         ### XXX we're assuming that all the next statements MUST
         ### be hashrefs. is this correct?
-        shift @$v;
+        my @v = @$v;
+        shift @v;
         my $op = uc $1;
 
         D
             && $self->___log(
-            "Special operator detected: $op " . Dumper( $v ) );
+            "Special operator detected: $op " . Dumper( \@v ) );
 
         my @clauses;
-        for my $href ( @$v ) {
+        for my $href ( @v ) {
             D
                 && $self->___log( "Dispatch ->_dispatch_struct({ $k, "
                     . Dumper( $href )

--- a/t/query.t
+++ b/t/query.t
@@ -3,6 +3,7 @@ use Test::More tests => 7;
 use strict;
 use warnings;
 
+use Storable qw(dclone);
 use WebService::Solr::Query;
 
 subtest 'Unescapes' => sub {
@@ -202,7 +203,9 @@ done_testing();
 sub _check {
     my %t = @_;
 
+    my $query = dclone($t{ query });
     my $q = WebService::Solr::Query->new( $t{ query } );
     isa_ok( $q, 'WebService::Solr::Query' );
     is( $q->stringify, $t{ expect }, $t{ expect } );
+    is_deeply($t{ query }, $query, 'query not modified');
 }


### PR DESCRIPTION
Modifying the query while serialising, while not caching the serialised form, breaks repeated serialisations of the same query, as demonstrated below:

```
1> my $q = WebService::Solr::Query->new({ foo => [ -and => { -prohibit => 3404862 }, { -prohibit => 3404863 } ] })
[…]
2> "$q"
$res[1] = '(((-foo:"3404862") AND (-foo:"3404863")))'
3> "$q"
Not a SCALAR reference at /home/ilmari/.perlbrew/libs/18.1@std/lib/perl5/WebService/Solr/Query.pm line 149.
4> my $q = WebService::Solr::Query->new({ foo => [ -and => 3404862, 3404863 ] })
[…]
5> "$q"
$res[3] = '(((foo:"3404862") AND (foo:"3404863")))'
6> "$q"
$res[4] = '((foo:"3404862" OR foo:"3404863"))'
```